### PR TITLE
Add themed HTML loading screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Release/
 .sconsign.dblite
 /*.d
 *.o
+title.webp
 
 # User-installed plugins
 plugins/

--- a/SConstruct
+++ b/SConstruct
@@ -77,7 +77,7 @@ if env["mode"] == "emcc":
 		"--preload-file", "keys.txt",
 		"--preload-file", "recent.txt",
 		#"--preload-file", "dummy@saves/dummy",
-		"--emrun",
+		#"--emrun",  # useful in dev, but causes hundreds of errors in prod
 		"-g4"
 	])
 	env.Append(LIBS = [
@@ -191,6 +191,8 @@ if env["mode"] == "emcc":
     outname += ".html"
 sky = env.Program(outname, RecursiveGlob("*.cpp", buildDirectory), LIBPATH='.')
 
+if env["mode"] == "emcc":
+    env.Command("title.webp", "images/_menu/title.webp", Copy("$TARGET", "$SOURCE"))
 
 # Install the binary:
 env.Install("$DESTDIR$PREFIX/games", sky)

--- a/es2.html
+++ b/es2.html
@@ -26,7 +26,7 @@
           width: 100%;
           min-height: 10%;
       }
-      #status {
+      .status {
           background-color: hsl(60,20%,90%);
           text-align: center;
           height: 0;
@@ -36,22 +36,104 @@
           color: black;
           border: none;
           padding: 0 1em;
-          position: absolute;
-          right: 0; width: 50%;
-          bottom: 0;
+          width: 50%;
+      }
+      .loading {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: -1;
+        background-color: black;
+        background-image: url("./title.webp");
+        background-repeat: no-repeat;
+        background-position: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+      .progress-bar-section {
+        margin-top: 40%;
+        font-family: "Lucida Console", Monaco, monospace;
+        color: #4e4e4e;
+        text-align: center;
+
+      }
+      .progress-bar {
+        width: 400px;
+        height: 20px;
+        background-color: #dddddd;
+      }
+      .progress {
+        height: 100%;
+        width: 1%;
+        transition: width .2s;
+        background-color: #6e6e6e;
+      }
+      .debug {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 70%;
+        background-color: lightgreen;
+        z-index: 2;
+        display: flex;
+        flex-direction: column;
+        resize: horizontal;
+        overflow: auto;
+        display: none;
       }
     </style>
   </head>
   <body>
-    <div id="status">Downloading...</div>
-
-    <input type="file" id="file-selector">
+    <div class="loading">
+      <div class="progress-bar-section">
+        <p class="progress-text">Downloading data...</p>
+        <div class="progress-bar">
+          <div class="progress"></div>
+        </div>
+      </div>
+    </div>
+    <div class="debug">
+      <h1>Debug panel</h1>
+      <p> press backslash to disable </p>
+      <div class="status">Downloading...</div>
+      <textarea id="output" rows="8"></textarea>
+    </div>
 
     <canvas id="canvas" oncontextmenu="event.preventDefault()"></canvas>
-
-    <textarea id="output" rows="8"></textarea>
     
     <script type='text/javascript'>
+      window.addEventListener('keydown', (e) => {
+        if (e.code === 'Backslash') {
+          e.preventDefault();
+          const debug = document.querySelector('.debug');
+          if (debug.style.display === 'none') {
+            debug.style.display = 'initial';
+          } else {
+            debug.style.display = 'none'
+          }
+        }
+      }, {capture: true})
+      const progressBar = document.querySelector('.progressBar');
+      const progress = document.querySelector('.progress');
+      const progressText = document.querySelector('.progress-text');
+      function updateProgress(numerator, denominator) {
+        progress.style.width = `${numerator / denominator * 100}%`;
+        if (numerator === denominator) {
+          progress.style.transition = 'none';
+          progressText.textContent = "Downloading complete, loading..."
+        }
+      }
+      // Prevents known errors which fire thousands of times from making the console hard to use
+      function errFilter(text) {
+        // ignore errors about missing image frames
+        if (/missing frame/.exec(text)) text = null;
+      }
+      window.updateProgress = updateProgress;
       var Module = {
           print: (function(text) {
               var element = document.getElementById('output');
@@ -65,11 +147,19 @@
                   }
               };
           })(),
-          printErr: function(text) { console.error(text); },
-          setStatus: (function(text) {
-              var element = document.getElementById('status');
+          printErr: function(text) {
+            text = errFilter(text)
+            if (text) console.error(text);
+          },
+          setStatus: (function() {
+              const element = document.querySelector('.status');
               if (element) element.textContent = ''; // clear browser cache
-              return function(text) { element.textContent = text; };
+              const fractionRe = /([0-9]+)\/([0-9]+)/
+              return function setStatus(text) {
+                element.textContent = text;
+                const match = fractionRe.exec(text)
+                if (match) updateProgress(parseInt(match[1]), parseInt(match[2]));
+              };
           })(),
           canvas: document.getElementById('canvas'),
       };


### PR DESCRIPTION
Also removes the --emrun flag from the build process because when built like this, hundreds of requests are sent to stdio.html which does not exist without emrun (sending errors back to the server to be displayed in the terminal).

![image](https://user-images.githubusercontent.com/458879/95682562-b2f1eb00-0b9a-11eb-944a-013f2a5cc9fc.png)