### PR TITLE
Allow upload of save games with HTML interface

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -203,12 +203,9 @@ interface "load menu"
 		center -440 155
 		dimensions 80 30
 	active if "pilot selected"
-	button i "Import"
-		center -355 155
-		dimensions 80 30
 	button D "Delete"
-		center -270 155
-		dimensions 80 30
+ 		center -285 155
+ 		dimensions 90 30
 
 	active if "pilot alive"
 	button a "_Add Snapshot"

--- a/es2.html
+++ b/es2.html
@@ -104,6 +104,12 @@
       <textarea id="output" rows="8"></textarea>
     </div>
 
+    <div class="upload-saves">
+      <input type="button" value="Upload save game files" onclick="document.querySelector('#file-selector').click();" />
+      <input type="file" style="display: none;" id="file-selector" multiple="multiple">
+      <button class="dismiss-upload">dismiss</button>
+    </div>
+
     <canvas id="canvas" oncontextmenu="event.preventDefault()"></canvas>
 
     <script src="js/cached-resource.js"></script>
@@ -139,6 +145,20 @@
         // ignore errors about missing image frames
         if (/missing frame/.exec(text)) text = null;
       }
+      document.querySelector('#file-selector').addEventListener("change", async function() {
+        // write every file uploaded to the filesystem
+        for (const file of [...this.files]) {
+          const data = new Uint8Array(await file.arrayBuffer());
+          const path = 'saves/' + file.name;
+          const stream = FS.open(path, 'w+');
+          FS.write(stream, data, 0, data.length, 0);
+          FS.close(stream);
+        }
+      });
+      document.querySelector('.dismiss-upload').addEventListener('click', function() {
+        this.parentNode.style.display = 'none';
+      });
+
       var Module = {
           print: (function(text) {
               var element = document.getElementById('output');

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -221,10 +221,6 @@ bool LoadPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command& command, boo
                 "Any progress will be lost, unless you have saved other snapshots. "
                 "Are you sure you want to do that?"));
     }
-    else if ((key == 'i') && !selectedPilot.empty())
-    {
-        printf("Emscripten load file\n");
-    }
     else if (key == 'b' || command.Has(Command::MENU) || (key == 'w' && (mod & (KMOD_CTRL | KMOD_GUI))))
         GetUI()->Pop(this);
     else if ((key == SDLK_DOWN || key == SDLK_UP) && !files.empty())


### PR DESCRIPTION
Uploading save games with HTML.

I just updated https://thomasballinger.github.io/es-web-build/endless-sky.html to be a preview of this.

Current limitations:
- this doesn't work until the FS object is globally available; so this interface actually shouldn't be visible until (or the action should block on) the loading process.
- If the pilot load screen is already open, this does not update it. That's a candidate for a hook that could be called from JavaScript.