### PR TITLE
Fix 3x mode in the browser build.

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -206,105 +206,109 @@ void GameLoop(PlayerInfo& player, Conversation& conversation, bool& debugMode)
 
     auto gameloop = [](void* data) {
         context* c = static_cast<context*>(data);
-        if (c->toggleTimeout)
-            --c->toggleTimeout;
 
-        // Handle any events that occurred in this frame.
-        SDL_Event event;
-        while (SDL_PollEvent(&event))
-        {
-            // int mpe = c->menuPanels->IsEmpty();
-            // int gpe = c->gamePanels->IsEmpty();
-            UI& activeUI = (c->menuPanels->IsEmpty() ? *c->gamePanels : *c->menuPanels);
+        while (true) {
+            if (c->toggleTimeout)
+                --c->toggleTimeout;
 
-            // If the mouse moves, reset the cursor movement timeout.
-            if (event.type == SDL_MOUSEMOTION)
-                c->cursorTime = 0;
+            // Handle any events that occurred in this frame.
+            SDL_Event event;
+            while (SDL_PollEvent(&event))
+            {
+                // int mpe = c->menuPanels->IsEmpty();
+                // int gpe = c->gamePanels->IsEmpty();
+                UI& activeUI = (c->menuPanels->IsEmpty() ? *c->gamePanels : *c->menuPanels);
 
-            if (c->debugMode && event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_BACKQUOTE)
-            {
-                c->isPaused = !c->isPaused;
-            }
-            else if (
-                event.type == SDL_KEYDOWN && c->menuPanels->IsEmpty() && Command(event.key.keysym.sym).Has(Command::MENU)
-                && !c->gamePanels->IsEmpty() && c->gamePanels->Top()->IsInterruptible())
-            {
-                // User pressed the Menu key.
-                c->menuPanels->Push(shared_ptr<Panel>(new MenuPanel(*c->player, *c->gamePanels)));
-            }
-            else if (event.type == SDL_QUIT)
-            {
-                c->menuPanels->Quit();
-            }
-            else if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
-            {
-                // The window has been resized. Adjust the raw screen size
-                // and the OpenGL viewport to match.
-                GameWindow::AdjustViewport();
-            }
-            else if (activeUI.Handle(event))
-            {
-                // The UI handled the event.
-            }
-            else if (
-                event.type == SDL_KEYDOWN && !c->toggleTimeout
-                && (Command(event.key.keysym.sym).Has(Command::FULLSCREEN)
-                    || (event.key.keysym.sym == SDLK_RETURN && (event.key.keysym.mod & KMOD_ALT))))
-            {
-                c->toggleTimeout = 30;
-                GameWindow::ToggleFullscreen();
-            }
-            else if (
-                event.type == SDL_KEYDOWN && !event.key.repeat && (Command(event.key.keysym.sym).Has(Command::FASTFORWARD)))
-            {
-                c->isFastForward = !c->isFastForward;
-            }
-        }
-        SDL_Keymod mod = SDL_GetModState();
-        Font::ShowUnderlines(mod & KMOD_ALT);
+                // If the mouse moves, reset the cursor movement timeout.
+                if (event.type == SDL_MOUSEMOTION)
+                    c->cursorTime = 0;
 
-        // In full-screen mode, hide the cursor if inactive for ten seconds,
-        // but only if the player is flying around in the main view.
-        bool inFlight = (c->menuPanels->IsEmpty() && c->gamePanels->Root() == c->gamePanels->Top());
-        ++c->cursorTime;
-        bool shouldShowCursor = (!GameWindow::IsFullscreen() || c->cursorTime < 600 || !inFlight);
-        if (shouldShowCursor != c->showCursor)
-        {
-            c->showCursor = shouldShowCursor;
-            SDL_ShowCursor(c->showCursor);
-        }
+                if (c->debugMode && event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_BACKQUOTE)
+                {
+                    c->isPaused = !c->isPaused;
+                }
+                else if (
+                    event.type == SDL_KEYDOWN && c->menuPanels->IsEmpty() && Command(event.key.keysym.sym).Has(Command::MENU)
+                    && !c->gamePanels->IsEmpty() && c->gamePanels->Top()->IsInterruptible())
+                {
+                    // User pressed the Menu key.
+                    c->menuPanels->Push(shared_ptr<Panel>(new MenuPanel(*c->player, *c->gamePanels)));
+                }
+                else if (event.type == SDL_QUIT)
+                {
+                    c->menuPanels->Quit();
+                }
+                else if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
+                {
+                    // The window has been resized. Adjust the raw screen size
+                    // and the OpenGL viewport to match.
+                    GameWindow::AdjustViewport();
+                }
+                else if (activeUI.Handle(event))
+                {
+                    // The UI handled the event.
+                }
+                else if (
+                    event.type == SDL_KEYDOWN && !c->toggleTimeout
+                    && (Command(event.key.keysym.sym).Has(Command::FULLSCREEN)
+                        || (event.key.keysym.sym == SDLK_RETURN && (event.key.keysym.mod & KMOD_ALT))))
+                {
+                    c->toggleTimeout = 30;
+                    GameWindow::ToggleFullscreen();
+                }
+                else if (
+                    event.type == SDL_KEYDOWN && !event.key.repeat && (Command(event.key.keysym.sym).Has(Command::FASTFORWARD)))
+                {
+                    c->isFastForward = !c->isFastForward;
+                }
+            }
+            SDL_Keymod mod = SDL_GetModState();
+            Font::ShowUnderlines(mod & KMOD_ALT);
 
-        // Tell all the panels to step forward, then draw them.
-        ((!c->isPaused && c->menuPanels->IsEmpty()) ? c->gamePanels : c->menuPanels)->StepAll();
+            // In full-screen mode, hide the cursor if inactive for ten seconds,
+            // but only if the player is flying around in the main view.
+            bool inFlight = (c->menuPanels->IsEmpty() && c->gamePanels->Root() == c->gamePanels->Top());
+            ++c->cursorTime;
+            bool shouldShowCursor = (!GameWindow::IsFullscreen() || c->cursorTime < 600 || !inFlight);
+            if (shouldShowCursor != c->showCursor)
+            {
+                c->showCursor = shouldShowCursor;
+                SDL_ShowCursor(c->showCursor);
+            }
 
-        // Caps lock slows the frame rate in debug mode.
-        // Slowing eases in and out over a couple of frames.
-        if ((mod & KMOD_CAPS) && inFlight && c->debugMode)
-        {
+            // Tell all the panels to step forward, then draw them.
+            ((!c->isPaused && c->menuPanels->IsEmpty()) ? c->gamePanels : c->menuPanels)->StepAll();
+
+            // Caps lock slows the frame rate in debug mode.
+            // Slowing eases in and out over a couple of frames.
+            if ((mod & KMOD_CAPS) && inFlight && c->debugMode)
+            {
 #ifndef __EMSCRIPTEN__
-            if (c->frameRate > 10)
-            {
-                c->frameRate = max(c->frameRate - 5, 10);
-                c->timer.SetFrameRate(c->frameRate);
-            }
+                if (c->frameRate > 10)
+                {
+                    c->frameRate = max(c->frameRate - 5, 10);
+                    c->timer.SetFrameRate(c->frameRate);
+                }
 #endif
-        }
-        else
-        {
-#ifndef __EMSCRIPTEN__
-            if (c->frameRate < 60)
-            {
-                c->frameRate = min(c->frameRate + 5, 60);
-                c->timer.SetFrameRate(c->frameRate);
             }
+            else
+            {
+#ifndef __EMSCRIPTEN__
+                if (c->frameRate < 60)
+                {
+                    c->frameRate = min(c->frameRate + 5, 60);
+                    c->timer.SetFrameRate(c->frameRate);
+                }
 #endif
 
-            if (c->isFastForward && inFlight)
-            {
-                c->skipFrame = (c->skipFrame + 1) % 3;
-                if (c->skipFrame)
-                    return;
+                if (c->isFastForward && inFlight)
+                {
+                    c->skipFrame = (c->skipFrame + 1) % 3;
+                    if (c->skipFrame)
+                        continue;
+                }
             }
+            break;
         }
 
         Audio::Step();


### PR DESCRIPTION
A messy fix to fast forward mode. Previously the browser skipped rendering of frames, but didn't run the simulation any faster in fast forward mode, so the effect was a slowed framerate with no change to game speed.

The native codepath now may now simulate a couple extra frames before clearing out a menu but it seems fine.