### PR TITLE
Fix asteroid sprite animations

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -857,6 +857,8 @@ void Engine::Go()
 	}
 	condition.notify_all();
 #else
+	++step;
+	drawTickTock = !drawTickTock;
 	CalculateStep();
 	calcTickTock = drawTickTock;
 #endif // ES_NO_THREADS


### PR DESCRIPTION
This fixes asteroid animations in the browser, but I can't say I understand it fully and I'm just guessing that we also need the drawTickTock toggle, it's not necessary to fix asteroids.