### PR TITLE
Stop using emscripten HTML shell

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -65,7 +65,6 @@ if env["mode"] == "emcc":
 		"-s", "FETCH=1"
 	]
 	env.Append(LINKFLAGS = [
-		"--shell-file", "es2.html",
 		"--source-map-base", "http://localhost:6931/",
 		"-s", "WASM_MEM_MAX=2147483648", # 2GB
 		"-s", "INITIAL_MEMORY=838860800", # 800MB
@@ -188,7 +187,7 @@ env.Library("webpdemux", [
 
 outname = "endless-sky"
 if env["mode"] == "emcc":
-    outname += ".html"
+    outname += ".js"
 sky = env.Program(outname, RecursiveGlob("*.cpp", buildDirectory), LIBPATH='.')
 
 if env["mode"] == "emcc":

--- a/endless-sky.html
+++ b/endless-sky.html
@@ -198,9 +198,5 @@
 
     addMainScriptTag();
     </script>
-    <!--
-    No longer used, but leaving a target to keep the existing build script working
-    {{{ SCRIPT }}}
-    -->
   </body>
 </html>


### PR DESCRIPTION
Now that the .js file is being loaded manually, there's no need for the `--shell-file` build argument and .html output. Instead the .js file can be build directly. This is slightly simpler but more importantly it makes editing JavaScript no longer require a build step.