### PR TITLE
Persist save files to IndexedDB

### DIFF
--- a/endless-sky.html
+++ b/endless-sky.html
@@ -247,6 +247,8 @@
             FS.write(stream, data, 0, data.length, 0);
             FS.close(stream);
           }
+          // syncfs(false) means save to IndexedDB
+          await new Promise((resolve) => FS.syncfs(false, resolve));
         });
       });
       document.querySelector('.dismiss-upload').addEventListener('click', function() {

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -43,6 +43,10 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <ctime>
 #include <sstream>
 
+#ifdef __EMSCRIPTEN__
+#    include <emscripten.h>
+#endif
+
 using namespace std;
 
 
@@ -354,6 +358,15 @@ void PlayerInfo::Save() const
 	}
 		
 	Save(filePath);
+
+#ifdef __EMSCRIPTEN__
+	EM_ASM(
+	   // syncfs(false) means save in-memory fs to persistent storage
+	   FS.syncfs(false, function(err) {
+		   assert(!err);
+		   console.log("persisted save file to IndexedDB.");
+	}););
+#endif
 }
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -61,14 +61,19 @@ void InitConsole();
 int main(int argc, char* argv[])
 {
 #ifdef __EMSCRIPTEN__
-    EM_ASM(FS.mkdir('/saves'); FS.mount(IDBFS, {}, '/saves');
+    EM_ASM(FS.mkdir('/saves');
+           FS.mount(IDBFS, {}, '/saves');
 
            // sync from persisted state into memory and then
            // run the 'test' function
            FS.syncfs(
                true, function(err) {
                    assert(!err);
-				   console.log("IndexedDB loaded!");
+                   const contents = FS.lookupPath('saves').node.contents;
+                   const numFiles = Object.keys(contents).length;
+                   console.log(
+                       numFiles ? numFiles : "No",
+                       "save files found in IndexedDB.");
                }););
 #endif
     // Handle command-line arguments


### PR DESCRIPTION
I didn't realize IDBFS requires FS.syncfs() calls to persist to and load from IndexedDB. This adds these calls on save and on save game upload.

> 